### PR TITLE
Bug fix

### DIFF
--- a/lib/aural-coding.coffee
+++ b/lib/aural-coding.coffee
@@ -95,7 +95,7 @@ class AuralCoding
       source.stop(@context.currentTime + 0.6)
 
   keystrokeForKeyboardEvent: (event) ->
-    keyIdentifier = event.keyIdentifier
+    keyIdentifier = if event.keyIdentifier then event.keyIdentifier else String.fromCharCode(event.keyCode);
     if keyIdentifier.indexOf('U+') is 0
       hexCharCode = keyIdentifier[2..]
       charCode = parseInt(hexCharCode, 16)


### PR DESCRIPTION
Chrome dropped support for "keyIdentifier" since version 54.

Addresses #13 

More about it [here](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyIdentifier)